### PR TITLE
keep leftover movement after aplying dividor

### DIFF
--- a/dts/bindings/pixart,pmw3610.yml
+++ b/dts/bindings/pixart,pmw3610.yml
@@ -15,6 +15,9 @@ properties:
   snipe-layers:
     type: array
     default: []
+  text-layers:
+    type: array
+    default: []
   automouse-layer:
     type: int
     default: -1

--- a/src/pixart.h
+++ b/src/pixart.h
@@ -15,7 +15,7 @@
 extern "C" {
 #endif
 
-enum pixart_input_mode { MOVE = 0, SCROLL, SNIPE };
+enum pixart_input_mode { MOVE = 0, SCROLL, SNIPE, TEXT };
 
 /* device data structure */
 struct pixart_data {
@@ -59,6 +59,8 @@ struct pixart_config {
     int32_t *scroll_layers;
     size_t snipe_layers_len;
     int32_t *snipe_layers;
+    size_t text_layers_len;
+    int32_t *text_layers;
 };
 
 #ifdef __cplusplus

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -77,8 +77,8 @@ static inline void tap_key(uint32_t param1) {
     	.behavior_dev = "key_press",
     	.param1 = param1,
     };
-    zmk_behavior_queue_add(0, behavior, true, 10);
-    zmk_behavior_queue_add(0, behavior, false, 10);
+    zmk_behavior_queue_add(0, behavior, true, 1);
+    zmk_behavior_queue_add(0, behavior, false, 1);
 }
 
 // checked and keep


### PR DESCRIPTION
When you move the mouse very slowly while using a dividor in the config sometimes the cursor doesn't move.
This is because when applying the dividor your movement gets rounded to 0.
The changes here keep track of the remainder of the division when applying the dividor and use them in the next calculation.

tested on my wireless charybdis nano.